### PR TITLE
Move loadConfig call outside the "case" to match recent change to live-chat-overlay

### DIFF
--- a/public/overlay/index.html
+++ b/public/overlay/index.html
@@ -25,11 +25,12 @@ pushstream.onmessage = function(data,id,channel) {
 
   switch(data.command) {
 
+    if(data.config) {
+      loadConfig(data.config);
+    }
+
     case 'show':
       hideMessageImmediately();
-      if(data.config) {
-        loadConfig(data.config);
-      }
       if(data.html) {
         showLegacyMessage(data);
       } else {


### PR DESCRIPTION
This is minor change to public/overlay/index.html to move the call to loadConfig outside the case statement. This will load the configuration if it was sent with the "hide" command (as live-chat-overlay does now).

The only real impact is that the remote window will be updated with the desired settings when receiving the "hide" command, and not only a "show" command.